### PR TITLE
Fix C String from_raw crash

### DIFF
--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -121,7 +121,7 @@ pub enum OrtApiError {
     Msg(String),
     /// Details as reported by the ONNX C API in case of error cannot be converted to UTF-8
     #[error("Error calling ONNX Runtime C function and failed to convert error message to UTF-8")]
-    IntoStringError(std::ffi::IntoStringError),
+    IntoStringError(std::str::Utf8Error),
 }
 
 /// Error from downloading pre-trained model from the [ONNX Model Zoo](https://github.com/onnx/models).

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -160,9 +160,8 @@ fn g_ort() -> sys::OrtApi {
 }
 
 fn char_p_to_string(raw: *const i8) -> Result<String> {
-    let c_string = unsafe { std::ffi::CString::from_raw(raw as *mut i8) };
-
-    match c_string.into_string() {
+    let c_string = unsafe { std::ffi::CStr::from_ptr(raw as *mut i8) };
+    match c_string.to_str().map(|s| s.to_owned()) {
         Ok(string) => Ok(string),
         Err(e) => Err(OrtApiError::IntoStringError(e)),
     }


### PR DESCRIPTION
  - when an OrtError was created using a `from_raw`, the application would crash
    when it called `drop` on that error due to a null pointer. Replacing `from_raw`
    with `CStr::from_ptr` resolves the unexpected crash.