### PR TITLE
Update ndarray to 0.15.x

### DIFF
--- a/onnxruntime/Cargo.toml
+++ b/onnxruntime/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["model-fetching"]
 onnxruntime-sys = {version = "0.0.11", path = "../onnxruntime-sys"}
 
 lazy_static = "1.4"
-ndarray = "0.14"
+ndarray = "0.15"
 thiserror = "1.0"
 tracing = "0.1"
 


### PR DESCRIPTION
  - required to allow usage of concatenate with Strings as 0.14
    requires the Copy trait